### PR TITLE
Handle dotted project directories when finding sessions

### DIFF
--- a/export_claude_session.py
+++ b/export_claude_session.py
@@ -93,11 +93,15 @@ def identify_current_session(sessions, project_dir):
 
 def find_project_sessions(project_path):
     """Find all JSONL session files for the current project."""
+    project_path = str(project_path)
     # Convert project path to Claude's directory naming convention
-    project_dir_name = project_path.replace('/', '-')
+    # Claude normalizes project directories by replacing path separators AND dots
+    # in the working directory path with hyphens (see issue #4).
+    normalized_project_path = project_path.replace('\\', '/')
+    project_dir_name = normalized_project_path.replace('/', '-').replace('.', '-')
     if project_dir_name.startswith('-'):
         project_dir_name = project_dir_name[1:]
-    
+
     claude_project_dir = Path.home() / '.claude' / 'projects' / f'-{project_dir_name}'
     
     if not claude_project_dir.exists():

--- a/tests/test_find_project_sessions.py
+++ b/tests/test_find_project_sessions.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from export_claude_session import find_project_sessions
+
+
+def test_find_project_sessions_handles_dot_in_project_path(tmp_path, monkeypatch):
+    """Claude replaces dots with dashes in project directory names."""
+    fake_home = tmp_path / "home"
+    claude_dir = fake_home / ".claude" / "projects" / "-mnt-c-project-git"
+    claude_dir.mkdir(parents=True)
+
+    session_file = claude_dir / "session123.jsonl"
+    session_file.write_text("{}\n", encoding="utf-8")
+
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+
+    sessions = find_project_sessions("/mnt/c/project.git")
+
+    assert [session["path"] for session in sessions] == [session_file]


### PR DESCRIPTION
## Summary
- ensure Claude project directory lookup normalizes both path separators and dots before searching for session files
- add regression test covering dotted project paths to guard against future regressions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d18dc9f68483218b2bbb596d85c746